### PR TITLE
Use ref for PhantomData

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ impl ShtSensor for sensor_class::ShtGeneric {}
 #[derive(Debug, Default)]
 pub struct ShtCx<S: ShtSensor, I2C> {
     /// The chosen target sensor.
-    sensor: PhantomData<S>,
+    sensor: PhantomData<*const S>,
     /// The concrete I²C device implementation.
     i2c: I2C,
     /// The I²C device address.


### PR DESCRIPTION
From Rust docs[1]:

> Adding a field of type PhantomData<T> indicates that your type owns
> data of type T. This in turn implies that when your type is dropped,
> it may drop one or more instances of the type T. This has bearing on
> the Rust compiler's drop check analysis.

> If your struct does not in fact own the data of type T, it is better
> to use a reference type, like PhantomData<&'a T> (ideally) or
> PhantomData<*const T> (if no lifetime applies), so as not to indicate
> ownership.

[1] https://doc.rust-lang.org/std/marker/struct.PhantomData.html#ownership-and-the-drop-check