### PR TITLE
Revert "Use ref for PhantomData (#25)"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl ShtSensor for sensor_class::ShtGeneric {}
 #[derive(Debug, Default)]
 pub struct ShtCx<S: ShtSensor, I2C> {
     /// The chosen target sensor.
-    sensor: PhantomData<*const S>,
+    sensor: PhantomData<S>,
     /// The concrete I²C device implementation.
     i2c: I2C,
     /// The I²C device address.


### PR DESCRIPTION
This reverts commit edbe0973ac6ccbd7946325d5723d85981cbad1a3.

The reason is that when using `*const T`, the wrapping struct is not
`Send` anymore. This prevents the use as an RTFM resource.