### PR TITLE
Allow reading raw measurement data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 - [add] Allow reading raw measurement data (#28)
+- [add] Temperature/Humidity: Expose `from_raw` constructor (#28)
 
 ## 0.10.0 - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+- [add] Allow reading raw measurement data (#28)
+
 ## 0.10.0 - 2020-10-23
 
 - [add] Provide non-blocking API for measurements (#16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - [add] Allow reading raw measurement data (#28)
 - [add] Temperature/Humidity: Expose `from_raw` constructor (#28)
+- [add] Impl `Copy` for all measurement data types (#28)
 
 ## 0.10.0 - 2020-10-23
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,13 +1,13 @@
 /// A temperature measurement.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Temperature(i32);
 
 /// A humidity measurement.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Humidity(i32);
 
 /// A combined temperature / humidity measurement.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Measurement {
     /// The measured temperature.
     pub temperature: Temperature,
@@ -19,7 +19,7 @@ pub struct Measurement {
 ///
 /// The raw values are of type u16. They require a conversion formula for
 /// conversion to a temperature / humidity value (see datasheet).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct RawMeasurement {
     /// The measured temperature (raw value).
     pub temperature: u16,
@@ -151,7 +151,7 @@ mod tests {
         };
 
         // std::convert::From
-        let measurement1 = Measurement::from(raw.clone());
+        let measurement1 = Measurement::from(raw);
         assert_eq!(measurement1.temperature.0, 23730);
         assert_eq!(measurement1.humidity.0, 62968);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ impl From<RawMeasurement> for Measurement {
 
 impl Temperature {
     /// Create a new `Temperature` from a raw measurement result.
-    pub(crate) fn from_raw(raw: u16) -> Self {
+    pub fn from_raw(raw: u16) -> Self {
         Self(convert_temperature(raw))
     }
 
@@ -55,7 +55,7 @@ impl Temperature {
 
 impl Humidity {
     /// Create a new `Humidity` from a raw measurement result.
-    pub(crate) fn from_raw(raw: u16) -> Self {
+    pub fn from_raw(raw: u16) -> Self {
         Self(convert_humidity(raw))
     }
 


### PR DESCRIPTION
Add two new methods:

- `get_measurement_result_raw`
- `get_partial_measurement_result_raw`

Additionally, improve docs.